### PR TITLE
Update Jenkins plugins in jenkins

### DIFF
--- a/jenkins/plugins.yaml
+++ b/jenkins/plugins.yaml
@@ -5,3 +5,6 @@ controller:
     - git:5.6.0
     - configuration-as-code:1897.v79281e066ea_7
     - sse-gateway:1.23
+jenkins:
+  controller:
+    installPlugins: []


### PR DESCRIPTION
#### 💡️ Rationale

This pull request updates the Jenkins plugins in `cd-jenkins` to their latest versions. Keeping plugins up-to-date ensures we have the latest features, bug fixes and security patches.

#### 🔵 Affected components

This change updates the Jenkins controller pod in the `cd-jenkins` Helm release. During the rolling update, there may be a brief jenkins outage.

## Plugin Updates

- `sse-gateway` updated from `` to `1.27` - [CHANGELOG](https://plugins.jenkins.io/sse-gateway)

This PR has been generated by [fetch-and-post-jenkins-updates-cd](https://github.com/dimaserbenyuk/github-runners/blob/6adbe4a2fc3e9579a63eab7f73221ca96a59394c/.github/workflows/fetch-jenkins-plg.yaml).