### PR TITLE
Update Jenkins plugins in jenkins

### DIFF
--- a/jenkins/plugins.yaml
+++ b/jenkins/plugins.yaml
@@ -4,4 +4,4 @@ controller:
     - workflow-aggregator:600.vb_57cdd26fdd7
     - git:5.6.0
     - configuration-as-code:1897.v79281e066ea_7
-    - sse-gateway:1.23
+    - sse-gateway:1.27


### PR DESCRIPTION
#### 💡️ Rationale

This pull request updates the Jenkins plugins in `cd-jenkins` to their latest versions. Keeping plugins up-to-date ensures we have the latest features, bug fixes and security patches.

#### 🔵 Affected components

This change updates the Jenkins controller pod in the `cd-jenkins` Helm release. During the rolling update, there may be a brief jenkins outage.

## Plugin Updates

- `sse-gateway` updated from `1.23` to `1.27` - [CHANGELOG](https://plugins.jenkins.io/sse-gateway)

This PR has been generated by [fetch-and-post-jenkins-updates-cd](https://github.com/dimaserbenyuk/github-runners/blob/1564029dc7fd5bd5ec04c11db388e12670f7faa8/.github/workflows/fetch-jenkins-plg.yaml).